### PR TITLE
[cmake] Disable tests if not top level project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,10 @@ project(WsprEncoded LANGUAGES CXX)
 
 include(cppcheck.cmake)
 
-include(CTest)
-enable_testing()
-
 add_subdirectory(src)
-add_subdirectory(test)
+
+if(PROJECT_IS_TOP_LEVEL)
+    include(CTest)
+    enable_testing()
+    add_subdirectory(test)
+endif()


### PR DESCRIPTION
- PROJECT_IS_TOP_LEVEL is used to gate the inclusion of test related cmake files to fix problems observed in integrating into zephyr-rtos build